### PR TITLE
format amounts and other improvements

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -39,6 +39,7 @@ export default function MyApp(props: AppProps) {
 
   useEffect(() => {
     if (isValidQuery || !router.isReady) return;
+
     router.push({ query: { network: "mainnet" } });
   }, [query]);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import TVLChart from "../src/components/tvl-chart";
 import { useQueryPools } from "../src/hooks/pools";
 import { useQuerySoroswapTVL } from "../src/hooks/soroswap";
 import { useQueryTokens } from "../src/hooks/tokens";
-import { formatTokenAmount } from "../src/utils/utils";
+import { formatNumberToMoney, formatTokenAmount } from "../src/utils/utils";
 import TransactionsTable from "../src/components/transaction-table/transactions-table";
 import { useQueryAllEvents } from "../src/hooks/events";
 import useEventTopicFilter from "../src/hooks/use-event-topic-filter";
@@ -91,7 +91,7 @@ export default function Home() {
               <Typography>TVL:</Typography>
               <LoadingSkeleton isLoading={soroswapTVL.isLoading} height={20}>
                 <Typography fontWeight={600}>
-                  {formatTokenAmount(soroswapTVL.data?.tvl, 7, "money")}
+                  {formatNumberToMoney(soroswapTVL.data?.tvl)}
                 </Typography>
                 {/* <PercentageChanged percentage={40.2} sx={{ fontWeight: 600 }} /> */}
               </LoadingSkeleton>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,22 +5,17 @@ import LoadingSkeleton from "../src/components/loading-skeleton";
 import PoolsTable from "../src/components/pools-table/pools-table";
 import TokensTable from "../src/components/tokens-table/tokens-table";
 import TVLChart from "../src/components/tvl-chart";
-import VolumeChart from "../src/components/volume-chart";
 import { useQueryPools } from "../src/hooks/pools";
-import {
-  useQuerySoroswapFees24h,
-  useQuerySoroswapTVL,
-  useQuerySoroswapVolume24h,
-} from "../src/hooks/soroswap";
+import { useQuerySoroswapTVL } from "../src/hooks/soroswap";
 import { useQueryTokens } from "../src/hooks/tokens";
-import { formatNumberToMoney } from "../src/utils/utils";
+import { formatTokenAmount } from "../src/utils/utils";
 import TransactionsTable from "../src/components/transaction-table/transactions-table";
 
 export default function Home() {
   const pools = useQueryPools();
   const tokens = useQueryTokens();
   const soroswapTVL = useQuerySoroswapTVL();
-  
+
   return (
     <>
       <Head>
@@ -34,7 +29,7 @@ export default function Home() {
           <Grid item xs={12} md={6}>
             <TVLChart />
           </Grid>
-{/*           <Grid item xs={12} md={6}>
+          {/*           <Grid item xs={12} md={6}>
             <VolumeChart />
           </Grid> */}
         </Grid>
@@ -91,7 +86,7 @@ export default function Home() {
               <Typography>TVL:</Typography>
               <LoadingSkeleton isLoading={soroswapTVL.isLoading} height={20}>
                 <Typography fontWeight={600}>
-                  {formatNumberToMoney(soroswapTVL.data?.tvl)}
+                  {formatTokenAmount(soroswapTVL.data?.tvl, 7, "money")}
                 </Typography>
                 {/* <PercentageChanged percentage={40.2} sx={{ fontWeight: 600 }} /> */}
               </LoadingSkeleton>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import TVLChart from "../src/components/tvl-chart";
 import { useQueryPools } from "../src/hooks/pools";
 import { useQuerySoroswapTVL } from "../src/hooks/soroswap";
 import { useQueryTokens } from "../src/hooks/tokens";
-import { formatNumberToMoney, formatTokenAmount } from "../src/utils/utils";
+import { formatNumberToMoney } from "../src/utils/utils";
 import TransactionsTable from "../src/components/transaction-table/transactions-table";
 import { useQueryAllEvents } from "../src/hooks/events";
 import useEventTopicFilter from "../src/hooks/use-event-topic-filter";

--- a/pages/pools/[id]/index.tsx
+++ b/pages/pools/[id]/index.tsx
@@ -18,6 +18,7 @@ import PoolChart from "../../../src/components/pool-chart";
 import Token from "../../../src/components/token";
 import useSavedPools from "../../../src/hooks/use-saved-pools";
 import {
+  formatNumberToMoney,
   formatTokenAmount,
   getExpectedAmountOfOne,
   getSoroswapAddLiquidityUrl,
@@ -245,7 +246,7 @@ const PoolPage = () => {
               <Typography>TVL</Typography>
               <LoadingSkeleton isLoading={pool.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatTokenAmount(pool.data?.tvl, 7, "money")}
+                  {formatNumberToMoney(pool.data?.tvl)}
                 </Typography>
               </LoadingSkeleton>
             </Box>
@@ -253,7 +254,7 @@ const PoolPage = () => {
               <Typography>Volume 24h</Typography>
               <LoadingSkeleton isLoading={pool.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatTokenAmount(pool.data?.volume24h, 7, "money")}
+                  {formatNumberToMoney(pool.data?.volume24h)}
                 </Typography>
               </LoadingSkeleton>
             </Box>

--- a/pages/pools/[id]/index.tsx
+++ b/pages/pools/[id]/index.tsx
@@ -18,7 +18,6 @@ import PoolChart from "../../../src/components/pool-chart";
 import Token from "../../../src/components/token";
 import useSavedPools from "../../../src/hooks/use-saved-pools";
 import {
-  formatNumberToMoney,
   formatTokenAmount,
   getExpectedAmountOfOne,
   getSoroswapAddLiquidityUrl,
@@ -27,6 +26,7 @@ import {
 } from "../../../src/utils/utils";
 import { useQueryEventsByPoolAddress } from "../../../src/hooks/events";
 import useEventTopicFilter from "../../../src/hooks/use-event-topic-filter";
+import TransactionsTable from "../../../src/components/transaction-table/transactions-table";
 
 const PoolPage = () => {
   const router = useRouter();

--- a/pages/pools/[id]/index.tsx
+++ b/pages/pools/[id]/index.tsx
@@ -19,6 +19,7 @@ import Token from "../../../src/components/token";
 import useSavedPools from "../../../src/hooks/use-saved-pools";
 import {
   formatNumberToMoney,
+  formatNumberToToken,
   formatTokenAmount,
   getExpectedAmountOfOne,
   getSoroswapAddLiquidityUrl,
@@ -262,7 +263,7 @@ const PoolPage = () => {
               <Typography>24h Fees</Typography>
               <LoadingSkeleton isLoading={pool.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatTokenAmount(pool.data?.fees24h, 7, "money")}
+                  {formatNumberToToken(pool.data?.fees24h)}
                 </Typography>
               </LoadingSkeleton>
             </Box>

--- a/pages/pools/[id]/index.tsx
+++ b/pages/pools/[id]/index.tsx
@@ -14,14 +14,12 @@ import AppBreadcrumbs from "../../../src/components/app-breadcrumbs";
 import Layout from "../../../src/components/layout";
 import Link from "next/link";
 import LoadingSkeleton from "../../../src/components/loading-skeleton";
-import PercentageChanged from "../../../src/components/percentage-changed";
 import PoolChart from "../../../src/components/pool-chart";
 import Token from "../../../src/components/token";
-import TransactionsTable from "../../../src/components/transaction-table/transactions-table";
 import useSavedPools from "../../../src/hooks/use-saved-pools";
 import {
   formatNumberToMoney,
-  formatNumberToToken,
+  formatTokenAmount,
   getExpectedAmountOfOne,
   getSoroswapAddLiquidityUrl,
   getSoroswapSwapUrl,
@@ -113,7 +111,9 @@ const PoolPage = () => {
                 fontSize: 16,
               }}
               label={
-                <Link href="/tokens/123">
+                <Link
+                  href={`/tokens/${token0?.contract}?network=${router.query.network}`}
+                >
                   <Box display="flex" alignItems="center" gap="4px">
                     <Token imageUrl={token0?.icon} width={20} height={20} />1{" "}
                     {token0code} ={" "}
@@ -136,7 +136,9 @@ const PoolPage = () => {
                 fontSize: 16,
               }}
               label={
-                <Link href="/tokens/123">
+                <Link
+                  href={`/tokens/${token1?.contract}?network=${router.query.network}`}
+                >
                   <Box display="flex" alignItems="center" gap="4px">
                     <Token imageUrl={token1?.icon} width={20} height={20} />1{" "}
                     {token1code} ={" "}
@@ -198,7 +200,11 @@ const PoolPage = () => {
                     {token0code}
                   </Typography>
                   <Typography fontSize={14}>
-                    {formatNumberToToken(pool.data?.reserve0)}
+                    {formatTokenAmount(
+                      pool.data?.reserve0,
+                      pool.data?.token0.decimals,
+                      "token"
+                    )}
                   </Typography>
                 </LoadingSkeleton>
               </Box>
@@ -218,7 +224,11 @@ const PoolPage = () => {
                     {token1code}
                   </Typography>{" "}
                   <Typography fontSize={14}>
-                    {formatNumberToToken(pool.data?.reserve1)}
+                    {formatTokenAmount(
+                      pool.data?.reserve1,
+                      pool.data?.token1?.decimals,
+                      "token"
+                    )}
                   </Typography>
                 </LoadingSkeleton>
               </Box>
@@ -227,7 +237,7 @@ const PoolPage = () => {
               <Typography>TVL</Typography>
               <LoadingSkeleton isLoading={pool.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatNumberToMoney(pool.data?.tvl)}
+                  {formatTokenAmount(pool.data?.tvl, 7, "money")}
                 </Typography>
               </LoadingSkeleton>
             </Box>
@@ -235,7 +245,7 @@ const PoolPage = () => {
               <Typography>Volume 24h</Typography>
               <LoadingSkeleton isLoading={pool.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatNumberToMoney(pool.data?.volume24h)}
+                  {formatTokenAmount(pool.data?.volume24h, 7, "money")}
                 </Typography>
               </LoadingSkeleton>
             </Box>
@@ -243,7 +253,7 @@ const PoolPage = () => {
               <Typography>24h Fees</Typography>
               <LoadingSkeleton isLoading={pool.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatNumberToMoney(pool.data?.fees24h)}
+                  {formatTokenAmount(pool.data?.fees24h, 7, "money")}
                 </Typography>
               </LoadingSkeleton>
             </Box>

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -159,11 +159,7 @@ const TokenPage = () => {
               <Typography>TVL</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatTokenAmount(
-                    token.data?.tvl,
-                    token.data?.asset.decimals,
-                    "money"
-                  )}
+                  {formatNumberToMoney(token.data?.tvl)}
                 </Typography>
               </LoadingSkeleton>
 
@@ -176,11 +172,7 @@ const TokenPage = () => {
               <Typography>24h Trading Vol</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatTokenAmount(
-                    token.data?.volume24h,
-                    token.data?.asset.decimals,
-                    "money"
-                  )}
+                  {formatNumberToMoney(token.data?.volume24h)}
                 </Typography>
               </LoadingSkeleton>
 
@@ -193,11 +185,7 @@ const TokenPage = () => {
               <Typography>7d Trading Vol</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatTokenAmount(
-                    token.data?.volume7d,
-                    token.data?.asset.decimals,
-                    "money"
-                  )}
+                  {formatNumberToMoney(token.data?.volume7d)}
                 </Typography>
               </LoadingSkeleton>
 

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -12,6 +12,7 @@ import useMounted from "../../../src/hooks/use-mounted";
 import useSavedTokens from "../../../src/hooks/use-saved-tokens";
 import {
   formatNumberToMoney,
+  formatTokenAmount,
   getSoroswapAddLiquidityUrl,
   getSoroswapSwapUrl,
   openInNewTab,
@@ -158,7 +159,11 @@ const TokenPage = () => {
               <Typography>TVL</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatNumberToMoney(token.data?.tvl)}
+                  {formatTokenAmount(
+                    token.data?.tvl,
+                    token.data?.asset.decimals,
+                    "money"
+                  )}
                 </Typography>
               </LoadingSkeleton>
 
@@ -171,7 +176,11 @@ const TokenPage = () => {
               <Typography>24h Trading Vol</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatNumberToMoney(token.data?.volume24h)}
+                  {formatTokenAmount(
+                    token.data?.volume24h,
+                    token.data?.asset.decimals,
+                    "money"
+                  )}
                 </Typography>
               </LoadingSkeleton>
 
@@ -184,7 +193,11 @@ const TokenPage = () => {
               <Typography>7d Trading Vol</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatNumberToMoney(token.data?.volume7d)}
+                  {formatTokenAmount(
+                    token.data?.volume7d,
+                    token.data?.asset.decimals,
+                    "money"
+                  )}
                 </Typography>
               </LoadingSkeleton>
 
@@ -197,7 +210,11 @@ const TokenPage = () => {
               <Typography>24h Fees</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatNumberToMoney(token.data?.fees24h)}
+                  {formatTokenAmount(
+                    token.data?.fees24h,
+                    token.data?.asset.decimals,
+                    "money"
+                  )}
                 </Typography>
               </LoadingSkeleton>
             </Box>

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -12,7 +12,7 @@ import useMounted from "../../../src/hooks/use-mounted";
 import useSavedTokens from "../../../src/hooks/use-saved-tokens";
 import {
   formatNumberToMoney,
-  formatTokenAmount,
+  formatNumberToToken,
   getSoroswapAddLiquidityUrl,
   getSoroswapSwapUrl,
   openInNewTab,
@@ -198,11 +198,7 @@ const TokenPage = () => {
               <Typography>24h Fees</Typography>
               <LoadingSkeleton isLoading={token.isLoading} variant="text">
                 <Typography variant="h5">
-                  {formatTokenAmount(
-                    token.data?.fees24h,
-                    token.data?.asset.decimals,
-                    "money"
-                  )}
+                  {formatNumberToToken(token.data?.fees24h)}
                 </Typography>
               </LoadingSkeleton>
             </Box>

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -11,12 +11,11 @@ import {
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { ReactNode } from "react";
-import { XLM_ADDRESS } from "../constants/constants";
-import { useQueryToken } from "../hooks/tokens";
 import { formatNumberToMoney } from "../utils/utils";
 import LoadingSkeleton from "./loading-skeleton";
 import BasicMenu from "./menu";
 import NetworkSelector from "./network-selector";
+import { useQueryXLMPrice } from "../hooks/xlm-price";
 
 const LINKS = [
   {
@@ -44,7 +43,7 @@ export default function Layout({ children }: { children: ReactNode }) {
     return currentPath.includes(href);
   };
 
-  const xlm = useQueryToken({ tokenAddress: XLM_ADDRESS });
+  const xlm = useQueryXLMPrice();
 
   return (
     <main>
@@ -67,9 +66,12 @@ export default function Layout({ children }: { children: ReactNode }) {
                 px="8px"
                 borderRadius="4px"
               >
-                <Typography fontSize={12}>⚠️ *This is a beta version, and data computation is actively in progress.</Typography>
+                <Typography fontSize={12}>
+                  ⚠️ *This is a beta version, and data computation is actively
+                  in progress.
+                </Typography>
                 <Typography fontSize={12} color="green">
-                ⚠️
+                  ⚠️
                 </Typography>
                 <Box
                   bgcolor="red"
@@ -88,7 +90,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                   style={{ background: "gray" }}
                 >
                   <Typography fontSize={12}>
-                    {formatNumberToMoney(xlm.data?.price)}
+                    {formatNumberToMoney(xlm.data)}
                   </Typography>
                 </LoadingSkeleton>
               </Box>

--- a/src/components/pool-chart.tsx
+++ b/src/components/pool-chart.tsx
@@ -18,7 +18,7 @@ import {
 } from "../hooks/pools";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
-import { formatNumberToToken, formatTokenAmount } from "../utils/utils";
+import { formatNumberToToken } from "../utils/utils";
 
 type Charts = "volume" | "liquidity" | "fees";
 
@@ -158,9 +158,7 @@ const PoolChart = ({ poolAddress }: { poolAddress: string }) => {
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
               <Tooltip
-                formatter={(amount) =>
-                  formatTokenAmount(amount as number, 7, "token")
-                }
+                formatter={(amount) => formatNumberToToken(amount as number)}
               />
               <Area
                 type="monotone"

--- a/src/components/pool-chart.tsx
+++ b/src/components/pool-chart.tsx
@@ -18,7 +18,7 @@ import {
 } from "../hooks/pools";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
-import { formatTokenAmount } from "../utils/utils";
+import { formatNumberToToken, formatTokenAmount } from "../utils/utils";
 
 type Charts = "volume" | "liquidity" | "fees";
 
@@ -93,9 +93,7 @@ const PoolChart = ({ poolAddress }: { poolAddress: string }) => {
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
               <Tooltip
-                formatter={(amount) =>
-                  formatTokenAmount(amount as number, 7, "token")
-                }
+                formatter={(amount) => formatNumberToToken(amount as number)}
               />
               <Area
                 type="monotone"
@@ -130,9 +128,7 @@ const PoolChart = ({ poolAddress }: { poolAddress: string }) => {
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
               <Tooltip
-                formatter={(amount) =>
-                  formatTokenAmount(amount as number, 7, "token")
-                }
+                formatter={(amount) => formatNumberToToken(amount as number)}
               />
               <Bar dataKey="tvl" fill="#82ca9d" />
             </BarChart>

--- a/src/components/pool-chart.tsx
+++ b/src/components/pool-chart.tsx
@@ -18,6 +18,7 @@ import {
 } from "../hooks/pools";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
+import { formatTokenAmount } from "../utils/utils";
 
 type Charts = "volume" | "liquidity" | "fees";
 
@@ -91,7 +92,11 @@ const PoolChart = ({ poolAddress }: { poolAddress: string }) => {
                 dataKey="date"
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
-              <Tooltip />
+              <Tooltip
+                formatter={(amount) =>
+                  formatTokenAmount(amount as number, 7, "token")
+                }
+              />
               <Area
                 type="monotone"
                 dataKey="volume"
@@ -124,7 +129,11 @@ const PoolChart = ({ poolAddress }: { poolAddress: string }) => {
                 dataKey="date"
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
-              <Tooltip />
+              <Tooltip
+                formatter={(amount) =>
+                  formatTokenAmount(amount as number, 7, "token")
+                }
+              />
               <Bar dataKey="tvl" fill="#82ca9d" />
             </BarChart>
           </ResponsiveContainer>
@@ -152,7 +161,11 @@ const PoolChart = ({ poolAddress }: { poolAddress: string }) => {
                 dataKey="date"
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
-              <Tooltip />
+              <Tooltip
+                formatter={(amount) =>
+                  formatTokenAmount(amount as number, 7, "token")
+                }
+              />
               <Area
                 type="monotone"
                 dataKey="fees"

--- a/src/components/pools-table/pools-table.tsx
+++ b/src/components/pools-table/pools-table.tsx
@@ -16,6 +16,7 @@ import useTable from "../../hooks/use-table";
 import { Pool } from "../../types/pools";
 import {
   formatNumberToMoney,
+  formatTokenAmount,
   roundNumber,
   shouldShortenCode,
 } from "../../utils/utils";
@@ -163,7 +164,8 @@ export default function PoolsTable({
               {visibleRows.map((row, index) => {
                 return (
                   <TableRow
-                    onClick={() => onClickRow(row.pool)}
+                    component="a"
+                    href={`/pools/${row.pool}?network=${router.query.network}`}
                     key={index}
                     sx={{
                       ":hover": {
@@ -198,24 +200,20 @@ export default function PoolsTable({
                       {shouldShortenCode(row.token1.code)}
                     </TableCell>
                     <TableCell align="right">
-                      {formatNumberToMoney(row.tvl)}
+                      {formatTokenAmount(row.tvl, 7, "money")}
                     </TableCell>
                     <TableCell align="right">
-                      {/* {formatNumberToMoney(row.volume24h)} */}
-                      -
+                      {/* {formatNumberToMoney(row.volume24h)} */}-
                     </TableCell>
                     <TableCell align="right">
-                      {/* {formatNumberToMoney(row.volume7d)} */}
-                      -
+                      {/* {formatNumberToMoney(row.volume7d)} */}-
                     </TableCell>
                     <TableCell align="right">
-                      {/* {formatNumberToMoney(row.fees24h)} */}
-                      -
+                      {/* {formatNumberToMoney(row.fees24h)} */}-
                     </TableCell>
                     <TableCell align="right">
                       <Typography color="brown" fontSize={14}>
-                        {/* {roundNumber(row?.feesYearly ?? 0, 2)}% */}
-                        -
+                        {/* {roundNumber(row?.feesYearly ?? 0, 2)}% */}-
                       </Typography>
                       <Box display="flex" justifyContent="flex-end"></Box>
                     </TableCell>

--- a/src/components/pools-table/pools-table.tsx
+++ b/src/components/pools-table/pools-table.tsx
@@ -14,12 +14,7 @@ import { useRouter } from "next/router";
 import * as React from "react";
 import useTable from "../../hooks/use-table";
 import { Pool } from "../../types/pools";
-import {
-  formatNumberToMoney,
-  formatTokenAmount,
-  roundNumber,
-  shouldShortenCode,
-} from "../../utils/utils";
+import { formatNumberToMoney, shouldShortenCode } from "../../utils/utils";
 import Token from "../token";
 
 interface HeadCell {

--- a/src/components/pools-table/pools-table.tsx
+++ b/src/components/pools-table/pools-table.tsx
@@ -200,7 +200,7 @@ export default function PoolsTable({
                       {shouldShortenCode(row.token1.code)}
                     </TableCell>
                     <TableCell align="right">
-                      {formatTokenAmount(row.tvl, 7, "money")}
+                      {formatNumberToMoney(row.tvl)}
                     </TableCell>
                     <TableCell align="right">
                       {/* {formatNumberToMoney(row.volume24h)} */}-

--- a/src/components/token-chart.tsx
+++ b/src/components/token-chart.tsx
@@ -18,7 +18,7 @@ import {
 } from "../hooks/tokens";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
-import { formatNumberToMoney, formatTokenAmount } from "../utils/utils";
+import { formatNumberToMoney, formatNumberToToken } from "../utils/utils";
 
 type Charts = "volume" | "tvl" | "price";
 
@@ -93,9 +93,7 @@ const TokenChart = ({ tokenAddress }: { tokenAddress: string }) => {
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
               <Tooltip
-                formatter={(amount) =>
-                  formatTokenAmount(amount as number, 7, "token")
-                }
+                formatter={(amount) => formatNumberToMoney(amount as number)}
               />
               <Area
                 type="monotone"
@@ -130,9 +128,7 @@ const TokenChart = ({ tokenAddress }: { tokenAddress: string }) => {
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
               <Tooltip
-                formatter={(amount) =>
-                  formatTokenAmount(amount as number, 7, "token")
-                }
+                formatter={(amount) => formatNumberToToken(amount as number)}
               />
               <Bar dataKey="tvl" fill="#82ca9d" />
             </BarChart>

--- a/src/components/token-chart.tsx
+++ b/src/components/token-chart.tsx
@@ -18,6 +18,7 @@ import {
 } from "../hooks/tokens";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
+import { formatNumberToMoney, formatTokenAmount } from "../utils/utils";
 
 type Charts = "volume" | "tvl" | "price";
 
@@ -91,7 +92,11 @@ const TokenChart = ({ tokenAddress }: { tokenAddress: string }) => {
                 dataKey="date"
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
-              <Tooltip />
+              <Tooltip
+                formatter={(amount) =>
+                  formatTokenAmount(amount as number, 7, "token")
+                }
+              />
               <Area
                 type="monotone"
                 dataKey="volume"
@@ -124,7 +129,11 @@ const TokenChart = ({ tokenAddress }: { tokenAddress: string }) => {
                 dataKey="date"
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
-              <Tooltip />
+              <Tooltip
+                formatter={(amount) =>
+                  formatTokenAmount(amount as number, 7, "token")
+                }
+              />
               <Bar dataKey="tvl" fill="#82ca9d" />
             </BarChart>
           </ResponsiveContainer>
@@ -152,7 +161,9 @@ const TokenChart = ({ tokenAddress }: { tokenAddress: string }) => {
                 dataKey="date"
                 tickFormatter={(tick) => xAxisChartFormatter(tick)}
               />
-              <Tooltip />
+              <Tooltip
+                formatter={(amount) => formatNumberToMoney(amount as number)}
+              />
               <Area
                 type="monotone"
                 dataKey="price"

--- a/src/components/tokens-table/tokens-table.tsx
+++ b/src/components/tokens-table/tokens-table.tsx
@@ -183,14 +183,10 @@ export default function TokensTable({
                       <PercentageChanged percentage={row.priceChange24h} />
                     </TableCell> */}
                     <TableCell align="right">
-                      {formatTokenAmount(
-                        row.volume24h,
-                        row.asset?.decimals,
-                        "money"
-                      )}
+                      {formatNumberToMoney(row.volume24h)}
                     </TableCell>
                     <TableCell align="right">
-                      {formatTokenAmount(row.tvl, row.asset?.decimals, "money")}
+                      {formatNumberToMoney(row.tvl)}
                     </TableCell>
                   </TableRow>
                 );

--- a/src/components/tokens-table/tokens-table.tsx
+++ b/src/components/tokens-table/tokens-table.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/router";
 import * as React from "react";
 import useTable from "../../hooks/use-table";
 import { Token } from "../../types/tokens";
-import { formatNumberToMoney } from "../../utils/utils";
+import { formatNumberToMoney, formatTokenAmount } from "../../utils/utils";
 import TokenImage from "../token";
 
 interface HeadCell {
@@ -161,7 +161,8 @@ export default function TokensTable({
                         bgcolor: "#f5f5f5",
                       },
                     }}
-                    onClick={() => onClickRow(row.asset.contract)}
+                    component="a"
+                    href={`/tokens/${row.asset.contract}?network=${router.query.network}`}
                   >
                     <TableCell>{index + 1}</TableCell>
                     <TableCell
@@ -182,10 +183,14 @@ export default function TokensTable({
                       <PercentageChanged percentage={row.priceChange24h} />
                     </TableCell> */}
                     <TableCell align="right">
-                      {formatNumberToMoney(row.volume24h)}
+                      {formatTokenAmount(
+                        row.volume24h,
+                        row.asset?.decimals,
+                        "money"
+                      )}
                     </TableCell>
                     <TableCell align="right">
-                      {formatNumberToMoney(row.tvl)}
+                      {formatTokenAmount(row.tvl, row.asset?.decimals, "money")}
                     </TableCell>
                   </TableRow>
                 );

--- a/src/components/tokens-table/tokens-table.tsx
+++ b/src/components/tokens-table/tokens-table.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/router";
 import * as React from "react";
 import useTable from "../../hooks/use-table";
 import { Token } from "../../types/tokens";
-import { formatNumberToMoney, formatTokenAmount } from "../../utils/utils";
+import { formatNumberToMoney } from "../../utils/utils";
 import TokenImage from "../token";
 
 interface HeadCell {

--- a/src/components/transaction-table/transactions-table.tsx
+++ b/src/components/transaction-table/transactions-table.tsx
@@ -24,8 +24,6 @@ import {
   RouterEventType,
   RouterEventsAPIResponse,
 } from "../../types/router-events";
-import { useQueryAllEvents } from "../../hooks/events";
-import { UseQueryResult } from "@tanstack/react-query";
 import { UseEventTopicFilterReturnProps } from "../../hooks/use-event-topic-filter";
 
 TimeAgo.addDefaultLocale(en);

--- a/src/components/tvl-chart.tsx
+++ b/src/components/tvl-chart.tsx
@@ -3,7 +3,7 @@ import { AreaChart, Area, XAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { useQuerySoroswapTVLChart } from "../hooks/soroswap";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
-import { formatNumberToToken, formatTokenAmount } from "../utils/utils";
+import { formatNumberToToken } from "../utils/utils";
 
 const TVLChart = () => {
   const tvlChart = useQuerySoroswapTVLChart();

--- a/src/components/tvl-chart.tsx
+++ b/src/components/tvl-chart.tsx
@@ -3,7 +3,7 @@ import { AreaChart, Area, XAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { useQuerySoroswapTVLChart } from "../hooks/soroswap";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
-import { formatTokenAmount } from "../utils/utils";
+import { formatNumberToToken, formatTokenAmount } from "../utils/utils";
 
 const TVLChart = () => {
   const tvlChart = useQuerySoroswapTVLChart();
@@ -41,9 +41,7 @@ const TVLChart = () => {
               tickFormatter={(tick) => xAxisChartFormatter(tick)}
             />
             <Tooltip
-              formatter={(amount) =>
-                formatTokenAmount(amount as number, 7, "token")
-              }
+              formatter={(amount) => formatNumberToToken(amount as number)}
             />
             <Area
               type="monotone"

--- a/src/components/tvl-chart.tsx
+++ b/src/components/tvl-chart.tsx
@@ -3,6 +3,7 @@ import { AreaChart, Area, XAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { useQuerySoroswapTVLChart } from "../hooks/soroswap";
 import LoadingSkeleton from "./loading-skeleton";
 import { xAxisChartFormatter } from "../utils/x-axis-chart-formatter";
+import { formatTokenAmount } from "../utils/utils";
 
 const TVLChart = () => {
   const tvlChart = useQuerySoroswapTVLChart();
@@ -39,7 +40,11 @@ const TVLChart = () => {
               dataKey="date"
               tickFormatter={(tick) => xAxisChartFormatter(tick)}
             />
-            <Tooltip />
+            <Tooltip
+              formatter={(amount) =>
+                formatTokenAmount(amount as number, 7, "token")
+              }
+            />
             <Area
               type="monotone"
               dataKey="tvl"

--- a/src/hooks/use-query-network.ts
+++ b/src/hooks/use-query-network.ts
@@ -1,5 +1,4 @@
 import { useRouter } from "next/router";
-import { useEffect } from "react";
 
 type QueryNetwork = "mainnet" | "testnet";
 

--- a/src/hooks/xlm-price.ts
+++ b/src/hooks/xlm-price.ts
@@ -1,0 +1,15 @@
+import { fetchXLMPrice } from "../services/xlm-price";
+import { useQuery } from "@tanstack/react-query";
+import useQueryNetwork from "./use-query-network";
+
+const key = "xlm-price";
+
+export const useQueryXLMPrice = () => {
+  const { network, isValidQuery } = useQueryNetwork();
+
+  return useQuery({
+    queryKey: [key, network],
+    queryFn: fetchXLMPrice,
+    enabled: isValidQuery,
+  });
+};

--- a/src/services/xlm-price.ts
+++ b/src/services/xlm-price.ts
@@ -1,0 +1,6 @@
+import axiosInstance from "./axios";
+
+export const fetchXLMPrice = async () => {
+  const { data } = await axiosInstance.get<number>("/info/xlmPrice");
+  return data;
+};

--- a/src/utils/complete-chart.ts
+++ b/src/utils/complete-chart.ts
@@ -1,3 +1,5 @@
+import { formatTokenAmount } from "./utils";
+
 type DataItem = {
   date: string;
   [key: string]: any;

--- a/src/utils/complete-chart.ts
+++ b/src/utils/complete-chart.ts
@@ -1,5 +1,3 @@
-import { formatTokenAmount } from "./utils";
-
 type DataItem = {
   date: string;
   [key: string]: any;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,6 +5,11 @@ const soroswapAppUrl = process.env.NEXT_PUBLIC_SOROSWAP_APP_URL;
 
 export const formatNumberToMoney = (number: number | undefined) => {
   if (!number) return "-";
+
+  if (typeof number === "string") {
+    number = parseFloat(number);
+  }
+
   if (typeof number !== "number") return "$0.00";
 
   if (number > 1000000000) {
@@ -21,6 +26,11 @@ export const formatNumberToMoney = (number: number | undefined) => {
 
 export const formatNumberToToken = (number: number | undefined) => {
   if (!number) return "-";
+
+  if (typeof number === "string") {
+    number = parseFloat(number);
+  }
+
   if (typeof number !== "number") return "$0.00";
 
   if (number > 1000000000) {
@@ -139,4 +149,43 @@ export const formatEvent = (
   return `${toCamelCase(event)} ${shouldShortenCode(symbol0)} ${
     event === "swap" ? "for" : "and"
   } ${shouldShortenCode(symbol1)}`;
+};
+
+type Formatter = "money" | "token";
+
+export const formatTokenAmount = (
+  amount: BigNumber | string | number | undefined | null,
+  decimals: number = 7,
+  formatter?: Formatter
+): string => {
+  if (!amount) {
+    return "-";
+  }
+
+  if (!(amount instanceof BigNumber)) {
+    amount = BigNumber(amount);
+  }
+
+  let formatted = amount.toString();
+
+  if (decimals > 0) {
+    formatted = amount.shiftedBy(-decimals).toFixed(decimals).toString();
+
+    while (formatted[formatted.length - 1] === "0") {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+
+    if (formatted.endsWith(".")) {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+  }
+
+  if (formatter) {
+    if (formatter === "money")
+      formatted = formatNumberToMoney(parseFloat(formatted));
+    if (formatter === "token")
+      formatted = formatNumberToToken(parseFloat(formatted));
+  }
+
+  return formatted;
 };


### PR DESCRIPTION
added


-format amounts based on token decimals (need to merge https://github.com/soroswap/backend/pull/117)
-fix some hardcoded links in pool page
-obtain xlm price that is being show in the header from /xlmPrice endpoint instead of the /info/token/{xlm_address} endpoint to make it faster
-now table rows can be open in a new tab