### PR TITLE
Fix #81: Update token list tab to not be in Pool Page

### DIFF
--- a/pages/pools/[id]/index.tsx
+++ b/pages/pools/[id]/index.tsx
@@ -316,7 +316,7 @@ const PoolPage = () => {
       </Grid>
       <Box mt={8}>
         <Tabs
-          items={["Tokens", "Transactions"]}
+          items={["Transactions"]}
           endContent={(selected) => (
             <Row gap="8px">
               <SearchInput

--- a/pages/pools/[id]/index.tsx
+++ b/pages/pools/[id]/index.tsx
@@ -329,12 +329,6 @@ const PoolPage = () => {
         >
           {(selected) => (
             <Box mt={2}>
-              <RenderIf isTrue={selected === "Tokens"}>
-                <TokensTable
-                  rows={filteredTokens ?? []}
-                  isLoading={tokens.isLoading}
-                />
-              </RenderIf>
               <RenderIf isTrue={selected === "Transactions"}>
                 <TransactionsTable
                   rows={filteredEvents ?? []}


### PR DESCRIPTION
Fix #81: Remove token list tab from Pool Page

This PR removes the token list tab from the Pool Page, as it contains platform-wide information that is not relevant to the specific pool being viewed.

![image](https://github.com/user-attachments/assets/076cd057-335b-4759-bc3b-c0c7fcc52c08)
